### PR TITLE
Allow user defined ioctl

### DIFF
--- a/syscall/ioctl.lua
+++ b/syscall/ioctl.lua
@@ -206,7 +206,7 @@ local ioctl = strflag {
 }
 
 local override = arch.ioctl or {}
-if type(override) == "function" then override = override(_IO, _IOR, _IOW, _IORW) end
+if type(override) == "function" then override = override(_IO, _IOR, _IOW, _IOWR) end
 for k, v in pairs(override) do ioctl[k] = v end
 
 -- alternate names


### PR DESCRIPTION
This expose  `_IO*` functions in `ioctl` module to allow users to define any not yet defined ioctl.

BTW, here is the ioctls that I needed to define (to create a uinput device) if you want to add them too:

``` lua
UI_DEV_CREATE  = _IO ('U',   1)
UI_DEV_DESTROY = _IO ('U',   2)
UI_SET_EVBIT   = _IOW('U', 100, s.int)
UI_SET_KEYBIT  = _IOW('U', 101, s.int)
```
