### PR TITLE
Tests: Forcing current directory to be in front of the module lookup path

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -861,7 +861,7 @@ test_sockets_pipes = {
     local a = s:accept()
     assert(a.fd:block())
     local ok, err = c:connect(sa) -- Linux will have returned INPROGRESS above, other OS may have connected
-    assert(s:block()) -- force accept to wait 
+    assert(s:block()) -- force accept to wait
     a = a or assert(s:accept())
     -- a is a table with the fd, but also the inbound connection details
     assert(a.addr.sin_family == 2, "expect ipv4 connection")


### PR DESCRIPTION
So that installed code (if any) wouldn't interfere with working copy tests.
