### PR TITLE
Add to the table returned by init.lua

### DIFF
--- a/syscall/init.lua
+++ b/syscall/init.lua
@@ -40,7 +40,7 @@ local S = require "syscall.syscalls".init(abi, c, C, types, ioctl, fcntl)
 
 c.IOCTL = ioctl -- cannot put in S, needed for tests, cannot be put in c earlier due to deps
 
-S.abi, S.c, S.C, S.types, S.t = abi, c, C, types, t -- add to main table returned
+S.abi, S.c, S.C, S.types, S.t, S.pt, S.s = abi, c, C, types, t, pt, s -- add to main table returned
 
 -- add compatibility code
 S = require "syscall.compat".init(S)


### PR DESCRIPTION
The table returned when requiring syscall.init(abi) doesn't include the pointers and sizes of the structs, so in the examples (I was trying event.lua), S.s is a nil table.
