### PR TITLE
Add getdents on OpenBSD 5.5

### DIFF
--- a/syscall/openbsd/ffifunctions.lua
+++ b/syscall/openbsd/ffifunctions.lua
@@ -9,6 +9,8 @@ pcall, type, table, string
 
 local cdef = require "ffi".cdef
 
+local abi = require "syscall.abi"
+
 cdef[[
 int reboot(int howto);
 int ioctl(int d, unsigned long request, void *arg);
@@ -17,6 +19,11 @@ int ioctl(int d, unsigned long request, void *arg);
 int grantpt(int fildes);
 int unlockpt(int fildes);
 char *ptsname(int fildes);
+]]
+
+if abi.openbsd >= 5.5 then
+cdef[[
 int getdents(int fd, void *buf, size_t nbytes);
 ]]
+end
 


### PR DESCRIPTION
The util.dirtable helper will try to use getdents, but it doesn't exist with declaring it here.
