### PR TITLE
linux/types: Add __len metamethod for cpu_set_t

### DIFF
--- a/syscall/linux/types.lua
+++ b/syscall/linux/types.lua
@@ -998,6 +998,11 @@ mt.cpu_set = {
     for i = 0, s.cpu_set * 8 - 1 do if set:get(i) then tab[#tab + 1] = i end end
     return "{" .. table.concat(tab, ",") .. "}"
   end,
+  __len = function(set)
+    local n = 0
+    for i = 0, s.cpu_set * 8 - 1 do if set:get(i) then n=n+1 end end
+    return n
+  end
 }
 
 addtype(types, "cpu_set", "struct cpu_set_t", mt.cpu_set)


### PR DESCRIPTION
This makes the '#' operator return the number of elements in a cpu_set_t object. Originally the return value was always 128 based on the size of the structure rather than the number of elements set.

This change is immediately useful for some code of mine that depends on having affinity to one CPU core and wants to run:

    assert(#S.sched_getaffinity() == 1, "must be locked to one core")

Summary of original behavior:

    grindelwald$ sudo rlwrap ./snabb snsh -i
    Snabb> S=require("syscall")
    Snabb> =S.sched_getaffinity()
    {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47}
    Snabb> =#S.sched_getaffinity()
    128
    Snabb> S.sched_setaffinity(0, {0,1})
    Snabb> =#S.sched_getaffinity()
    128

and new behavior:

    grindelwald$ sudo rlwrap ./snabb snsh -i
    Snabb> S=require("syscall")
    Snabb> =S.sched_getaffinity()
    {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47}
    Snabb> =#S.sched_getaffinity()
    48
    Snabb> S.sched_setaffinity(0, {0,1})
    Snabb> =#S.sched_getaffinity()
    2