### PR TITLE
linux: BPF improvements

### DIFF
--- a/syscall/linux/constants.lua
+++ b/syscall/linux/constants.lua
@@ -426,7 +426,7 @@ c.SO = strflag(arch.SO or {
   PRIORITY    = 12,
   LINGER      = 13,
   BSDCOMPAT   = 14,
---REUSEPORT   = 15, -- new, may not be defined yet
+  REUSEPORT   = 15, -- new, may not be defined yet
   PASSCRED    = 16,
   PEERCRED    = 17,
   RCVLOWAT    = 18,
@@ -455,9 +455,19 @@ c.SO = strflag(arch.SO or {
   WIFI_STATUS        = 41,
   PEEK_OFF           = 42,
   NOFCS              = 43,
+  LOCK_FILTER        = 44,
+  SELECT_ERR_QUEUE   = 45,
+  BUSY_POLL          = 46,
+  MAX_PACING_RATE    = 47,
+  BPF_EXTENSIONS     = 48,
+  INCOMING_CPU       = 49,
+  ATTACH_BPF         = 50,
+  ATTACH_REUSEPORT_CBPF = 51,
+  ATTACH_REUSEPORT_EBPF = 52,
 })
 
 c.SO.GET_FILTER = c.SO.ATTACH_FILTER
+c.SO.DETACH_BPF = c.SO.DETACH_FILTER
 
 -- Maximum queue length specifiable by listen.
 c.SOMAXCONN = 128
@@ -2065,6 +2075,10 @@ c.BPF = multiflags {
   TXA        = 0x80,
   TO_LE      = 0x00,
   TO_BE      = 0x08,
+-- flags
+  ANY        = 0,
+  NOEXIST    = 1,
+  EXIST      = 2,
 }
 
 -- eBPF flags

--- a/syscall/linux/constants.lua
+++ b/syscall/linux/constants.lua
@@ -2068,7 +2068,7 @@ c.BPF = multiflags {
 }
 
 -- eBPF flags
-c.BPF_MAP = {
+c.BPF_MAP = strflag {
   UNSPEC           = 0,
   HASH             = 1,
   ARRAY            = 2,
@@ -2076,7 +2076,7 @@ c.BPF_MAP = {
   PERF_EVENT_ARRAY = 4,
 }
 
-c.BPF_CMD = {
+c.BPF_CMD = strflag {
   MAP_CREATE       = 0,
   MAP_LOOKUP_ELEM  = 1,
   MAP_UPDATE_ELEM  = 2,
@@ -2087,7 +2087,7 @@ c.BPF_CMD = {
   OBJ_GET          = 7,
 }
 
-c.BPF_PROG = {
+c.BPF_PROG = strflag {
   UNSPEC        = 0,
   SOCKET_FILTER = 1,
   KPROBE        = 2,

--- a/test/ctest-linux.lua
+++ b/test/ctest-linux.lua
@@ -80,6 +80,9 @@ c.BPF.CALL = nil
 c.BPF.EXIT = nil
 c.BPF.TO_LE = nil
 c.BPF.TO_BE = nil
+c.BPF.ANY = nil
+c.BPF.NOEXIST = nil
+c.BPF.EXIST = nil
 c.BPF.END = nil
 c.BPF.ARSH = nil
 c.BPF.XADD = nil
@@ -304,6 +307,17 @@ c.SO.PEEK_OFF = nil
 c.SO.GET_FILTER = nil
 c.SO.NOFCS = nil
 c.SO.WIFI_STATUS = nil
+c.SO.REUSEPORT = nil
+c.SO.LOCK_FILTER = nil
+c.SO.SELECT_ERR_QUEUE = nil
+c.SO.BUSY_POLL = nil
+c.SO.MAX_PACING_RATE = nil
+c.SO.BPF_EXTENSIONS = nil
+c.SO.INCOMING_CPU = nil
+c.SO.ATTACH_BPF = nil
+c.SO.DETACH_BPF = nil
+c.SO.ATTACH_REUSEPORT_CBPF = nil
+c.SO.ATTACH_REUSEPORT_EBPF = nil
 
 -- Musl changes some of the syscall constants in its 32/64 bit handling
 c.SYS.getdents = nil

--- a/test/linux-constants.lua
+++ b/test/linux-constants.lua
@@ -160,6 +160,13 @@ local function fixup_constants(abi, c)
   c.RTA.VIA = nil
   c.RTA.MFC_STATS = nil
   c.AUDIT_ARCH.AARCH64 = nil
+  c.SO.MAX_PACING_RATE = nil
+  c.SO.BPF_EXTENSIONS = nil
+  c.SO.INCOMING_CPU = nil
+  c.SO.ATTACH_BPF = nil
+  c.SO.DETACH_BPF = nil
+  c.SO.ATTACH_REUSEPORT_CBPF = nil
+  c.SO.ATTACH_REUSEPORT_EBPF = nil
 
   -- these are not even in linux git head headers or names wrong
   c.O.ASYNC = nil
@@ -228,6 +235,9 @@ local function fixup_constants(abi, c)
   c.BPF.XADD = nil
   c.BPF.JNE = nil
   c.BPF.MOV = nil
+  c.BPF.ANY = nil
+  c.BPF.EXIST = nil
+  c.BPF.NOEXIST = nil
 
   return c
 end


### PR DESCRIPTION
Added:
* `strflag/multiflag` support for constants
* returned `fd` is now wrapped in `t.fd`
* new constants and support for attaching BPF programs to sockets and `SO_REUSEPORT`