### PR TITLE
Remove unused variables from c.lua

### DIFF
--- a/syscall/linux/c.lua
+++ b/syscall/linux/c.lua
@@ -7,12 +7,8 @@ Note a fair number are being deprecated, see include/uapi/asm-generic/unistd.h u
 Some of these we already don't use, but some we do, eg use open not openat etc.
 ]]
 
-local require, error, assert, tonumber, tostring,
-setmetatable, pairs, ipairs, unpack, rawget, rawset,
-pcall, type, table, string, select = 
-require, error, assert, tonumber, tostring,
-setmetatable, pairs, ipairs, unpack, rawget, rawset,
-pcall, type, table, string, select
+local require, tonumber, pcall, select =
+require, tonumber, pcall, select
 
 local abi = require "syscall.abi"
 
@@ -34,7 +30,6 @@ local uint, ulong = ffi.typeof("unsigned int"), ffi.typeof("unsigned long")
 
 local h = require "syscall.helpers"
 local err64 = h.err64
-local errpointer = h.errpointer
 
 local i6432, u6432 = bit.i6432, bit.u6432
 
@@ -53,7 +48,6 @@ else
   arg64u = function(val) return u6432(val) end
 end
 -- _llseek very odd, preadv
-local function llarg64u(val) return u6432(val) end
 local function llarg64(val) return i6432(val) end
 
 local C = {}
@@ -69,7 +63,6 @@ local u64 = ffi.typeof("uint64_t")
 -- TODO could make these return errno here, also are these best casts?
 local syscall_long = ffi.C.syscall -- returns long
 local function syscall(...) return tonumber(syscall_long(...)) end -- int is default as most common
-local function syscall_uint(...) return uint(syscall_long(...)) end
 local function syscall_void(...) return void(syscall_long(...)) end
 local function syscall_off(...) return u64(syscall_long(...)) end -- off_t
 


### PR DESCRIPTION
Given https://github.com/justincormack/ljsyscall/pull/195 , I decided to run a linter on c.lua to see if there were other unused variables. This patch removes most of them.

Several other things were found by the linter, which this patch doesn't address. The non-use of signal strikes me as the most significant:
```
    c.lua:144:11: shadowing upvalue off1 on line 141
    c.lua:186:25: unused argument signal
    c.lua:287:35: shadowing upvalue nr on line 55
    c.lua:290:33: shadowing upvalue nr on line 55
```