### PR TITLE
Add more protection against fd double-close

### DIFF
--- a/syscall/syscalls.lua
+++ b/syscall/syscalls.lua
@@ -75,7 +75,13 @@ local function retiter(ret, err, array)
 end
 
 -- generic system calls
-function S.close(fd) return retbool(C.close(getfd(fd))) end
+function S.close(fd)
+  if fd == getfd(fd) then -- fd number
+    return retbool(C.close(getfd(fd)))
+  else                    -- fd object: avoid mulitple close
+    return fd:close()
+  end
+end
 function S.chdir(path) return retbool(C.chdir(path)) end
 function S.fchdir(fd) return retbool(C.fchdir(getfd(fd))) end
 function S.fchmod(fd, mode) return retbool(C.fchmod(getfd(fd), c.MODE[mode])) end


### PR DESCRIPTION
There are three ways to close a file descriptor object:

- S.close(fd)
- fd:close()
- garbage collection finalizer

This change ensures the close() system call is only called once: the
first time the file descriptor object is closed in any of these ways.

This logic already existed for fd:close() and garbage collection but
it was bypassed by S.close(fd). This has lead to double-close bugs in
practice.

Consider this example program:

    local fd = S.open("/etc/passwd")
    S.close(fd)
    collectgarbage()

On the parent commit this code would close the file descriptor twice,
once explicitly and then once with the GC finalizer:

    open("/etc/passwd", O_RDONLY)           = 3
    close(3)                                = 0
    close(3)                                = -1 EBADF (Bad file descriptor)

but with this commit it will close only once:

    open("/etc/passwd", O_RDONLY)           = 3
    close(3)                                = 0

This seems important because double-close bugs on file descriptors can
be very difficult to diagnose. If the file descriptor number has been
reused before the second close then the effect will be unpredictable.