### PR TITLE
Add SEEK_DATA and SEEK_HOLE constants

### DIFF
--- a/syscall/linux/constants.lua
+++ b/syscall/linux/constants.lua
@@ -311,6 +311,8 @@ c.SEEK = strflag {
   SET = 0,
   CUR = 1,
   END = 2,
+  DATA = 3,
+  HOLE = 4,
 }
 
 -- exit


### PR DESCRIPTION
Allow discovery of holes in files with lseek(2).

Fix #207

Signed-off-by: Justin Cormack <justin@specialbusservice.com>