### PR TITLE
Add CLOCK_ constants for OSX

### DIFF
--- a/syscall/osx/constants.lua
+++ b/syscall/osx/constants.lua
@@ -1109,6 +1109,17 @@ c.CLOCKTYPE = {
 
 c.CLOCKTYPE.REALTIME = c.CLOCKTYPE.SYSTEM
 
+c.CLOCK = strflag {
+  REALTIME             = 0,
+  MONOTONIC_RAW        = 4,
+  MONOTONIC_RAW_APPROX = 5,
+  MONOTONIC            = 6,
+  UPTIME_RAW           = 8,
+  UPTIME_RAW_APPROX    = 9,
+  PROCESS_CPUTIME_ID   = 12,
+  THREAD_CPUTIME_ID    = 16,
+}
+
 -- AT constants only in recent versions, should check when added
 c.AT_FDCWD = atflag {
   FDCWD = -2,
@@ -1122,4 +1133,3 @@ c.AT = multiflags {
 }
 
 return c
-


### PR DESCRIPTION
Since 10.12 these have been available; the functions were added
automatically.

See https://github.com/daurnimator/luatz/issues/11

Signed-off-by: Justin Cormack <justin@specialbusservice.com>