### PR TITLE
expose the gettid syscall on Linux

### DIFF
--- a/syscall/linux/c.lua
+++ b/syscall/linux/c.lua
@@ -175,6 +175,7 @@ end
 
 -- glibc caches pid, but this fails to work eg after clone().
 function C.getpid() return syscall(sys.getpid) end
+function C.gettid() return syscall(sys.gettid) end
 
 -- underlying syscalls
 function C.exit_group(status) return syscall(sys.exit_group, int(status)) end -- void return really

--- a/syscall/syscalls.lua
+++ b/syscall/syscalls.lua
@@ -428,6 +428,7 @@ function S.getpid() return C.getpid() end
 function S.getppid() return C.getppid() end
 function S.getgid() return C.getgid() end
 function S.getegid() return C.getegid() end
+function S.gettid() return C.gettid() end
 function S.setuid(uid) return retbool(C.setuid(uid)) end
 function S.setgid(gid) return retbool(C.setgid(gid)) end
 function S.seteuid(uid) return retbool(C.seteuid(uid)) end

--- a/test/linux.lua
+++ b/test/linux.lua
@@ -1925,6 +1925,9 @@ test.processes_linux = {
       assert(status.EXITSTATUS == 23, "exit should be 23")
     end
   end,
+  test_tid = function()
+     assert(S.getpid() == S.gettid(), "PID should be the same as TID")
+  end,
 }
 test.scheduler = {
   test_getcpu = function()


### PR DESCRIPTION
When using @jsitnicki  's rushit tool, we'd like to have a unique identifier for threads. The gettid() syscall would provide that.