### PR TITLE
Promptly close util.ls() dir fd; fix bug with deleted entries

### DIFF
--- a/syscall/bsd/syscalls.lua
+++ b/syscall/bsd/syscalls.lua
@@ -31,6 +31,7 @@ if C.getdirentries then
     basep = basep or t.long1()
     local ret, err = C.getdirentries(getfd(fd), buf, size, basep)
     if ret == -1 then return nil, t.error(err or errno()) end
+    if ret == 0 then return nil, nil end
     return t.dirents(buf, ret)
   end
 end

--- a/syscall/syscalls.lua
+++ b/syscall/syscalls.lua
@@ -741,6 +741,7 @@ if C.getdents then
     buf = buf or t.buffer(size)
     local ret, err = C.getdents(getfd(fd), buf, size)
     if ret == -1 then return nil, t.error(err or errno()) end
+    if ret == 0 then return nil, nil end
     return t.dirents(buf, ret)
   end
 end

--- a/syscall/types.lua
+++ b/syscall/types.lua
@@ -601,15 +601,10 @@ if bsdtypes then types = bsdtypes.init(c, types) end
 -- define dents type if dirent is defined
 if t.dirent then
   t.dirents = function(buf, size) -- buf should be char*
-    local d, i = nil, 0
+    local i = 0
     return function() -- TODO work out if possible to make stateless
-      if size > 0 and not d then
-        d = pt.dirent(buf)
-        i = i + d.d_reclen
-        return d
-      end
       while i < size do
-        d = pt.dirent(pt.char(d) + d.d_reclen)
+        local d = pt.dirent(buf + i)
         i = i + d.d_reclen
         if d.ino ~= 0 then return d end -- some systems use ino = 0 for deleted files before removed eg OSX; it is never valid
       end

--- a/syscall/util.lua
+++ b/syscall/util.lua
@@ -56,22 +56,19 @@ function util.ls(name, buf, size)
   if err then return nil, err end
   local di
   return function()
-    local d, first
-    repeat
-      if not di then
-        local err
-        di, err = fd:getdents(buf, size)
-        if not di then
-          fd:close()
-          error(err)
-        end
-        first = true
+    while true do
+      if di then
+        local d = di()
+        if d then return d.name, d end
       end
-      d = di()
-      if not d then di = nil end
-      if not d and first then return nil end
-    until d
-    return d.name, d
+      -- Fetch more entries.
+      local err
+      di, err = fd:getdents(buf, size)
+      if not di then
+        fd:close()
+        if err then error(err) else return nil end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This commit fixes two bugs:

  * It was impossible to distinguish between a nonempty batch of dirents
    that contains all deleted entries (d.ino == 0) and a terminal batch
    of dirents (size == 0).  To fix this, we modify the getdents /
    getdirentries interfaces to return nil, nil in the terminal case.
    This is an incompatible change, but most users are probably using
    the util.ls or util.dirtable methods.

  * The util.ls method left the directory FD open, to be later closed by
    GC.  This can lead to running out of FDs if GC doesn't happen soon
    enough.  The fix is to close the directory fd after the iterator
    terminates normally, in addition to closing the fd in error cases.