### PR TITLE
Make "offset" arg to lseek a signed integer

### DIFF
--- a/syscall/linux/c.lua
+++ b/syscall/linux/c.lua
@@ -164,7 +164,7 @@ else -- 64 bit
   function C.fstatfs(fd, buf) return syscall(sys.fstatfs, int(fd), void(buf)) end
   function C.preadv(fd, iov, iovcnt, offset) return syscall_long(sys.preadv, int(fd), void(iov), long(iovcnt), ulong(offset)) end
   function C.pwritev(fd, iov, iovcnt, offset) return syscall_long(sys.pwritev, int(fd), void(iov), long(iovcnt), ulong(offset)) end
-  function C.lseek(fd, offset, whence) return syscall_off(sys.lseek, int(fd), ulong(offset), int(whence)) end
+  function C.lseek(fd, offset, whence) return syscall_off(sys.lseek, int(fd), long(offset), int(whence)) end
   function C.sendfile(outfd, infd, offset, count)
     return syscall_long(sys.sendfile, int(outfd), int(infd), void(offset), ulong(count))
   end


### PR DESCRIPTION
Otherwise, passing a negative seek amount as a normal Lua number will
involve a cast from double to uint64.  In C it's undefined behavior when
a double outside the [0,2^64) range is cast to uint64.  In Lua we try to
additionally accomodate the range [-2^63, -1], but there is a bug on
x64-64 and might be a bug on other platforms:

  https://github.com/LuaJIT/LuaJIT/pull/415

However it's cheaper to simply target an int64_t when you want to allow
negative numbers, as is our case, because you don't have to do assembly
heroics for it to do what you want.  The `tonumber` call in the return
of `linux.lua:lseek` indicates anyway that our range is not the full
64-bit range, so we might as well restrict instead to long rather than
ulong.